### PR TITLE
Fix parser to correctly link calc example

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -12,7 +12,7 @@ import Lean
 import Paperproof
 
 example {m n : ℤ} (h1 : m + 3 ≤ 2 * n - 1) (h2 : n ≤ 5) : m ≤ 6 := by
-  have h3 : m + 3 ≤ 9 := by calc
+  have h3 : m + 3 ≤ 9 := calc
       m + 3 ≤ 2 * n - 1 := by gcongr
       _ ≤ 2 * 5 - 1 := by gcongr
       _ = 9 := by norm_num

--- a/Examples.lean
+++ b/Examples.lean
@@ -11,8 +11,13 @@ import Mathlib.Algebra.GCDMonoid.Multiset
 import Lean
 import Paperproof
 
+theorem simple_ex (n m : ℕ)
+  (h1 : ∀ {a b : Nat}, a + b = b + a)
+  (h2 : ∀ {a b : Nat}, a = b + b):
+    n + m = m + n := by
+  simp [h1, h2]
+
 example {m n : ℤ} (h1 : m + 3 ≤ 2 * n - 1) (h2 : n ≤ 5) : m ≤ 6 := by
-  have ⟨ p, q ⟩ : (3 = 3) ∧ (4 = 4) := ⟨ by rfl, by rfl ⟩
   have h3 := calc
       m + 3 ≤ 2 * n - 1 := by gcongr
       _ ≤ 2 * 5 - 1 := by gcongr

--- a/Examples.lean
+++ b/Examples.lean
@@ -12,7 +12,8 @@ import Lean
 import Paperproof
 
 example {m n : ℤ} (h1 : m + 3 ≤ 2 * n - 1) (h2 : n ≤ 5) : m ≤ 6 := by
-  have h3 := by calc
+  have ⟨ p, q ⟩ : (3 = 3) ∧ (4 = 4) := ⟨ by rfl, by rfl ⟩
+  have h3 := calc
       m + 3 ≤ 2 * n - 1 := by gcongr
       _ ≤ 2 * 5 - 1 := by gcongr
       _ = 9 := by norm_num

--- a/Examples.lean
+++ b/Examples.lean
@@ -12,7 +12,7 @@ import Lean
 import Paperproof
 
 example {m n : ℤ} (h1 : m + 3 ≤ 2 * n - 1) (h2 : n ≤ 5) : m ≤ 6 := by
-  have h3 : m + 3 ≤ 9 := calc
+  have h3 := by calc
       m + 3 ≤ 2 * n - 1 := by gcongr
       _ ≤ 2 * 5 - 1 := by gcongr
       _ = 9 := by norm_num

--- a/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createArrows.ts
+++ b/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createArrows.ts
@@ -75,13 +75,29 @@ const createArrows = (shared: UIShared): UIElement => {
         });
 
         // 3. Draw arrows between this tactic and `have` windows
-        if (tactic.haveWindowId && tactic.hypArrows[0]) {
-          const window = getWindowByHypId(shared.proofTree, tactic.hypArrows[0].toIds[0]);
-          if (!window) return
-          const fromWindowId = findIdInApp(shared.editor, CreateId.window(tactic.haveWindowId));
-          const toTacticId = findIdInApp(shared.editor, CreateId.hypTactic(tactic.id, null, window.id));
-          if (!fromWindowId || !toTacticId) return
-          DrawShape.arrow(shared.editor, fromWindowId, toTacticId, "goalArrow");
+        for (const haveWindowId of tactic.haveWindowIds) {
+          if (tactic.hypArrows[0]) {
+            const window = getWindowByHypId(
+              shared.proofTree,
+              tactic.hypArrows[0].toIds[0]
+            );
+            if (!window) return;
+            const fromWindowId = findIdInApp(
+              shared.editor,
+              CreateId.window(haveWindowId)
+            );
+            const toTacticId = findIdInApp(
+              shared.editor,
+              CreateId.hypTactic(tactic.id, null, window.id)
+            );
+            if (!fromWindowId || !toTacticId) return;
+            DrawShape.arrow(
+              shared.editor,
+              fromWindowId,
+              toTacticId,
+              "goalArrow"
+            );
+          }
         }
       });
     }

--- a/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createWindowInsides.ts
+++ b/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createWindowInsides.ts
@@ -128,10 +128,11 @@ const createWindowInsides = (shared: UIShared, parentId: TLParentId | undefined,
             CreateId.hypTactic(tactic.id, hypArrow.fromId, window.id)
           );
 
-          const haveWindows = shared.proofTree.windows
-            .filter((w) => tactic.haveWindowIds.includes(w.id))
+          const haveWindows = tactic.haveWindowIds
+            .flatMap(
+              (id) => shared.proofTree.windows.find((w) => w.id === id) ?? []
+            )
             .map((w) => createWindow(shared, parentId, w, depth + 1));
-          console.log("HAVE WINDOWS", tactic.haveWindowIds, haveWindows);
           const hTree: UIHypTree = {
             tactic: vStack(0, [hStack(shared.inBetweenMargin, haveWindows), tacticNode]),
             level,

--- a/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createWindowInsides.ts
+++ b/app/src/services/updateUI/services/buildProofTree/services/CreateElement/createWindowInsides.ts
@@ -129,8 +129,9 @@ const createWindowInsides = (shared: UIShared, parentId: TLParentId | undefined,
           );
 
           const haveWindows = shared.proofTree.windows
-            .filter(w => tactic.haveWindowId === w.id)
-            .map(w => createWindow(shared, parentId, w, depth + 1));
+            .filter((w) => tactic.haveWindowIds.includes(w.id))
+            .map((w) => createWindow(shared, parentId, w, depth + 1));
+          console.log("HAVE WINDOWS", tactic.haveWindowIds, haveWindows);
           const hTree: UIHypTree = {
             tactic: vStack(0, [hStack(shared.inBetweenMargin, haveWindows), tacticNode]),
             level,

--- a/app/src/services/updateUI/services/converter.ts
+++ b/app/src/services/updateUI/services/converter.ts
@@ -404,7 +404,6 @@ const recursive = (subSteps: LeanProofTree, pretty: ConvertedProofTree) => {
         "initialGoals" in subStep.haveDecl
           ? subStep.haveDecl.initialGoals
           : [getInitialGoal(subStep.haveDecl.subSteps)!];
-      console.log("Inital", initialGoals);
       const windows = initialGoals.map((goal) => ({
         id: newWindowId(),
         // Parent window is such that has our goalId as a hypothesis.

--- a/app/types/ConvertedProofTree.ts
+++ b/app/types/ConvertedProofTree.ts
@@ -31,7 +31,11 @@ export interface Tactic {
   // hmm
   isSuccess: boolean | string;
   successGoalId?: string;
-  haveWindowId?: string
+  // TODO: Those are actually `byWindow`s which were used to create
+  // parameters for this tactic. For example in
+  // `have <p, q> := <by rfl, by trivial>`
+  // there are 2 `byWindow`s.
+  haveWindowIds: string[];
 }
 
 export interface ConvertedProofTree {

--- a/app/types/LeanProofTree.ts
+++ b/app/types/LeanProofTree.ts
@@ -29,8 +29,13 @@ export type LeanHaveDecl = {
   haveDecl: {
     t: LeanTactic;
     subSteps: LeanProofTree;
-    initialGoal: string;
-  }
+  } & (
+    | { version: undefined; initialGoal: string }
+    | {
+        version: 2;
+        initialGoals: LeanGoal[];
+      }
+  );
 };
 
 export type LeanProofTree = (LeanTacticApp | LeanHaveDecl)[];

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -148,8 +148,10 @@ partial def BetterParser (context: Option ContextInfo) (infoTree : InfoTree) : R
                   allGoals} 
  
         let goals := (goalsBefore ++ goalsAfter).foldl HashSet.erase (noInEdgeGoals allGoals steps)
+        -- Important for have := calc for example, e.g. calc 3 < 4 ... 4 < 5 ...
+        let sortedGoals := goals.toArray.insertionSort (·.id < ·.id)
         -- TODO: have ⟨ p, q ⟩ : (3 = 3) ∧ (4 = 4) := ⟨ by rfl, by rfl ⟩ isn't supported yet
-        return {steps := [.haveDecl tacticApp goals.toList steps],
+        return {steps := [.haveDecl tacticApp sortedGoals.toList steps],
                 allGoals := HashSet.empty.insertMany (goalsBefore ++ goalsAfter)}
       | `(tactic| rw [$_,*] $(_)?)
       | `(tactic| rewrite [$_,*] $(_)?) =>

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -134,9 +134,7 @@ partial def BetterParser (context: Option ContextInfo) (infoTree : InfoTree) : R
 
       -- It's a tactic combinator
       match tInfo.stx with
-      -- TODO: can we grab all have's as one pattern match branch?
-      | `(tactic| have $_:letPatDecl)
-      | `(tactic| have $_ : $_ := $_) =>
+      | `(tactic| have $_:haveDecl) =>
         -- Something like `have p : a = a := rfl`
         if steps.isEmpty then
           return {steps := [.tacticApp tacticApp],

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -34,7 +34,7 @@ structure TacticApplication where
 inductive ProofStep := 
   | tacticApp (t : TacticApplication)
   | haveDecl (t: TacticApplication)
-    (initialGoal: String)
+    (initialGoals: List GoalInfo)
     (subSteps : List ProofStep)
   deriving Inhabited, ToJson, FromJson
 
@@ -143,10 +143,8 @@ partial def BetterParser (context: Option ContextInfo) (infoTree : InfoTree) : R
                   allGoals} 
  
         let goals := (goalsBefore ++ goalsAfter).foldl HashSet.erase (noInEdgeGoals allGoals steps)
-        let [initialGoal] := goals.toList
           -- TODO: have ⟨ p, q ⟩ : (a = a) × (b = b) := ⟨ by rfl, by rfl ⟩ isn't supported yet
-          | throwThe RequestError ⟨.invalidParams, s!"exactly one orphaned goal is expected for have with goalsAfter {toJson goalsAfter}, but found {toJson goals.toList}"⟩
-        return {steps := [.haveDecl tacticApp initialGoal.type steps],
+        return {steps := [.haveDecl tacticApp goals.toList steps],
                 allGoals := HashSet.empty.insertMany (goalsBefore ++ goalsAfter)}
       | `(tactic| rw [$_,*] $(_)?)
       | `(tactic| rewrite [$_,*] $(_)?) =>

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -60,11 +60,13 @@ def findHypsUsedByTactic (goalId: MVarId) (goalDecl : MetavarDecl) (mctxAfter : 
   let some expr := mctxAfter.eAssignment.find? goalId
     | return []
 
-  let fvarIds := (collectFVars {} expr).fvarIds
+  -- Need to instantiate it to get all fvars
+  let fullExpr ← instantiateExprMVars expr |>.run
+  let fvarIds := (collectFVars {} fullExpr).fvarIds
   let fvars := fvarIds.filterMap goalDecl.lctx.find?
   let proofFvars ← fvars.filterM (Meta.isProof ·.toExpr)
-  let pretty := proofFvars.map (fun x => x.userName)
-  dbg_trace s!"Used {pretty}"
+  -- let pretty := proofFvars.map (fun x => x.userName)
+  -- dbg_trace s!"Used {pretty}"
   return proofFvars.map (fun x => x.fvarId.name.toString) |>.toList
 
 -- Returns GoalInfo about unassigned goals from the provided list of goals

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -148,7 +148,7 @@ partial def BetterParser (context: Option ContextInfo) (infoTree : InfoTree) : R
                   allGoals} 
  
         let goals := (goalsBefore ++ goalsAfter).foldl HashSet.erase (noInEdgeGoals allGoals steps)
-          -- TODO: have ⟨ p, q ⟩ : (a = a) × (b = b) := ⟨ by rfl, by rfl ⟩ isn't supported yet
+        -- TODO: have ⟨ p, q ⟩ : (3 = 3) ∧ (4 = 4) := ⟨ by rfl, by rfl ⟩ isn't supported yet
         return {steps := [.haveDecl tacticApp goals.toList steps],
                 allGoals := HashSet.empty.insertMany (goalsBefore ++ goalsAfter)}
       | `(tactic| rw [$_,*] $(_)?)

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -135,6 +135,9 @@ partial def BetterParser (context: Option ContextInfo) (infoTree : InfoTree) : R
       -- For example a tactic like `done` which ensures there are no unsolved goals,
       -- or `focus` which only leaves one goal, however has no information for the tactic tree
       -- Note: tactic like `have` changes the goal as it adds something to the context
+      if goalsBefore.isEmpty then
+        return {steps, allGoals}
+
       let some mainGoalId := tInfo.goalsBefore.head?
         | return {steps, allGoals}
       let some mainGoalDecl := tInfo.mctxBefore.findDecl? mainGoalId


### PR DESCRIPTION
It fixes:
- haves without explicit type
- haves with multiple by's inside
- tracking what hypothesis tactic actually used in the mvar assignment instead of parsing syntax