### PR TITLE
Even Better Parser

### DIFF
--- a/_examples/development/Header.lean
+++ b/_examples/development/Header.lean
@@ -1,3 +1,6 @@
+/-
+  This is a development file for working with html header.
+-/
 import Mathlib.Data.Set.Basic
 import Paperproof
 

--- a/_examples/development/Rw.lean
+++ b/_examples/development/Rw.lean
@@ -1,0 +1,35 @@
+/-
+  This is a development file for checking how `rw`, `rwa`, `nth_rw`, etc. get rendered in Paperproof.
+-/
+import Mathlib.Tactic
+import Paperproof
+
+theorem commutativityOfIntersections
+(s t : Set Nat) : s ∩ t = t ∩ s := by
+  ext x
+  apply Iff.intro
+  rw [Set.mem_inter_iff, and_comm]
+
+theorem sss
+(s t : Set Nat) : s ∩ t = t ∩ s := by
+  ext x
+  apply Iff.intro
+  erw [Set.mem_inter_iff, and_comm]
+
+theorem www
+(s t : Set Nat) : s ∩ t = t ∩ s := by
+  ext x
+  apply Iff.intro
+  rw_mod_cast [Set.mem_inter_iff, and_comm]
+
+theorem ddd
+(s t : Set Nat) : s ∩ t = t ∩ s := by
+  ext x
+  apply Iff.intro
+  rwa [Set.mem_inter_iff, and_comm]
+
+example (h : a = 1) : a + a + a + a + a = 5 := by
+  nth_rewrite 2 3 [h]
+
+example (a b c : Nat) : (a + b) + c = (b + a) + c := by
+  nth_rw 2 [Nat.add_comm]

--- a/_examples/development/TEST.lean
+++ b/_examples/development/TEST.lean
@@ -1,0 +1,53 @@
+import Paperproof
+import Mathlib.Data.Set.Card
+import Mathlib.Tactic.Explode
+
+open Set
+variable {α β : Type*} {s t : Set α}
+
+-- TEST: rw; exact
+theorem TEST_encard_union_le (s t : Set α) : (s ∪ t).encard ≤ s.encard + t.encard := by
+  rw [← encard_union_add_encard_inter]; exact le_self_add
+
+-- TEST: anonymous functions
+theorem TEST_encard_insert_of_not_mem {a : α} (has : a ∉ s) : (insert a s).encard = s.encard + 1 := by
+  rw [← union_singleton, encard_union_eq (by simpa), encard_singleton]
+
+-- TEST: rw; apply; intro; exact
+theorem encard_le_encard_of_injOn (hf : MapsTo f s t) (f_inj : InjOn f s) :
+    s.encard ≤ t.encard := by
+  rw [← f_inj.encard_image]; apply encard_le_card; rintro _ ⟨x, hx, rfl⟩; exact hf hx
+
+-- TODO: use this code to create proper testing for our parser
+-- (https://github.com/leanprover/lean4/blob/bfb02be28168d05ae362d6d9a135ec93820ca1cb/src/Lean/Elab/InfoTrees.lean#L20)
+
+-- elab "aliasC " x:ident " ← " ys:ident* : command =>
+--   for y in ys do
+--     Lean.logInfo y
+
+-- elab "#explode " stx:term : command => Command.runTermElabM fun _ => do
+--   let (heading, e) ← try
+--     -- Adapted from `#check` implementation
+--     let theoremName : Name ← realizeGlobalConstNoOverloadWithInfo stx
+--     addCompletionInfo <| .id stx theoremName (danglingDot := false) {} none
+--     let decl ← getConstInfo theoremName
+--     let c : Expr := .const theoremName (decl.levelParams.map mkLevelParam)
+--     pure (m!"{MessageData.ofConst c} : {decl.type}", decl.value!)
+--   catch _ =>
+--     let e ← Term.elabTerm stx none
+--     Term.synthesizeSyntheticMVarsNoPostponing
+--     let e ← Term.levelMVarToParam (← instantiateMVars e)
+--     pure (m!"{e} : {← Meta.inferType e}", e)
+--   unless e.isSyntheticSorry do
+--     let entries ← explode e
+--     let fitchTable : MessageData ← entriesToMessageData entries
+--     logInfo <|← addMessageContext m!"{heading}\n\n{fitchTable}\n"
+
+
+/--
+info: lambda : True → True
+
+0│   │ a  ├ True
+1│0,0│ ∀I │ True → True
+-/
+-- #guard_msgs in #explode lambda

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperproof",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperproof",
-      "version": "1.6.5",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.26.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "paperproof",
   "displayName": "Paperproof",
   "description": "Lean therorem proving interface which feels like pen-and-paper proofs",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "publisher": "paperproof",
   "repository": {
     "type": "git",

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -105,7 +105,7 @@ def printGoalInfo (ctx : ContextInfo) (metavarContext : MetavarContext) (id : MV
   return ⟨ decl.userName.toString, (← ppExprWithInfos ppContext decl.type).fmt.pretty, hyps, id⟩
 
 -- Returns unassigned goals from the provided list of goals
-def getUnassignedGoals (goals : List MVarId) (mctx : MetavarContext) : IO (List MVarId) := do
+def getUnassignedGoals (goals : List MVarId) (mctx : MetavarContext) : RequestM (List MVarId) := do
   goals.filterMapM fun id => do
     if let none := mctx.findDecl? id then
       return none
@@ -184,7 +184,7 @@ def getRelevantGoalsAfter (mctxAfter: MetavarContext) (goalBeforeId: MVarId) (go
     | none      => pure #[]
   return goalsAfter.filter (λ g => assignedToThisGoal.contains g)
 
-partial def postNode (ctx : ContextInfo) (info : Info) (_: PersistentArray InfoTree) (results : List (Option Result)) : IO Result := do
+partial def postNode (ctx : ContextInfo) (info : Info) (_: PersistentArray InfoTree) (results : List (Option Result)) : RequestM Result := do
   -- Remove `Option.none` values from the `results` list (we have them because of the `.visitM` implementation)
   let results : List Result := results.filterMap id
   -- 1. Flatten `ProofStep`s
@@ -232,6 +232,5 @@ partial def postNode (ctx : ContextInfo) (info : Info) (_: PersistentArray InfoT
   newSteps := newSteps.map λ s => { s with spawnedGoals := orphanedGoals }
 
   return { steps := newSteps ++ steps, allGoals }
-
 
 partial def BetterParser (i : InfoTree) := i.visitM (postNode := postNode)

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -183,41 +183,40 @@ def getTacticStringUserActuallyWrote (tInfo : TacticInfo) : Option String :=
 def prettifyTacticString (tacticString: String) : String :=
   (tacticString.splitOn "\n").head!.trim
 
-partial def postNode (ctx : ContextInfo) (i : Info) (_: PersistentArray InfoTree) (res : List (Option Result)) : IO Result := do
-    let res := res.filterMap id
-    let some ctx := i.updateContext? ctx
-      | panic! "unexpected context node"
-    let steps := res.map (fun r => r.steps) |>.join
-    let allSubGoals := Std.HashSet.empty.insertMany $ res.bind (·.allGoals.toList)
-    if let .ofTacticInfo tInfo := i then
-      let some userWrittenTacticString := getTacticStringUserActuallyWrote tInfo | return { steps, allGoals := allSubGoals }
-      let tacticString := prettifyTacticString userWrittenTacticString
+partial def postNode (ctx : ContextInfo) (info : Info) (_: PersistentArray InfoTree) (res : List (Option Result)) : IO Result := do
+  let res := res.filterMap id
+  let some ctx := info.updateContext? ctx | panic! "unexpected context node"
+  let steps := res.map (fun r => r.steps) |>.join
+  let allSubGoals := Std.HashSet.empty.insertMany $ res.bind (·.allGoals.toList)
+  let .ofTacticInfo tInfo := info                                             | return { steps, allGoals := allSubGoals }
+  let .some userWrittenTacticString := getTacticStringUserActuallyWrote tInfo | return { steps, allGoals := allSubGoals }
 
-      let steps := prettifySteps tInfo.stx steps
+  let tacticString := prettifyTacticString userWrittenTacticString
 
-      let proofTreeEdges ← getGoalsChange ctx tInfo
-      let currentGoals := proofTreeEdges.map (fun ⟨ _, g₁, gs ⟩ => g₁ :: gs)  |>.join
-      let allGoals := allSubGoals.insertMany $ currentGoals
-      -- It's like tacticDependsOn but unnamed mvars instead of hyps.
-      -- Important to sort for have := calc for example, e.g. calc 3 < 4 ... 4 < 5 ...
-      let orphanedGoals := currentGoals.foldl Std.HashSet.erase (noInEdgeGoals allGoals steps)
-        |>.toArray.insertionSort (nameNumLt ·.id.name ·.id.name) |>.toList
+  let steps := prettifySteps tInfo.stx steps
 
-      let newSteps := proofTreeEdges.filterMap fun ⟨ tacticDependsOn, goalBefore, goalsAfter ⟩ =>
-       -- Leave only steps which are not handled in the subtree.
-        if steps.map (·.goalBefore) |>.elem goalBefore then
-          none
-        else
-          some {
-            tacticString,
-            goalBefore,
-            goalsAfter,
-            tacticDependsOn,
-            spawnedGoals := orphanedGoals
-          }
+  let proofTreeEdges ← getGoalsChange ctx tInfo
+  let currentGoals := proofTreeEdges.map (fun ⟨ _, g₁, gs ⟩ => g₁ :: gs)  |>.join
+  let allGoals := allSubGoals.insertMany $ currentGoals
+  -- It's like tacticDependsOn but unnamed mvars instead of hyps.
+  -- Important to sort for have := calc for example, e.g. calc 3 < 4 ... 4 < 5 ...
+  let orphanedGoals := currentGoals.foldl Std.HashSet.erase (noInEdgeGoals allGoals steps)
+    |>.toArray.insertionSort (nameNumLt ·.id.name ·.id.name) |>.toList
 
-      return { steps := newSteps ++ steps, allGoals }
+  let newSteps := proofTreeEdges.filterMap fun ⟨ tacticDependsOn, goalBefore, goalsAfter ⟩ =>
+    -- Leave only steps which are not handled in the subtree.
+    if steps.map (·.goalBefore) |>.elem goalBefore then
+      none
     else
-      return { steps, allGoals := allSubGoals}
+      some {
+        tacticString,
+        goalBefore,
+        goalsAfter,
+        tacticDependsOn,
+        spawnedGoals := orphanedGoals
+      }
+
+  return { steps := newSteps ++ steps, allGoals }
+
 
 partial def BetterParser (i : InfoTree) := i.visitM (postNode := postNode)

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -158,12 +158,10 @@ def prettifySteps_NOT_USED (ts : String) (steps : List ProofStep) : List ProofSt
 -- See `TEST.lean` for examples that don't work with the `prettifySteps_NOT_USED()` function.
 def prettifySteps_IMPERFECT (stx : Syntax) (steps : List ProofStep) : List ProofStep := Id.run do
   let prettifyRw (tacticString: String) (steps: List ProofStep) : List ProofStep := steps.map λ step =>
-    if step.tacticString.startsWith tacticString then step
-    else
-      let rwPart := if step.tacticString == "]"
-        then "rfl"
-        else step.tacticString.trim.dropRightWhile (· == ',')
-      { step with tacticString := s!"{tacticString} [{rwPart}]" }
+    let rwPart := if step.tacticString == "]"
+      then "rfl"
+      else step.tacticString.trim.dropRightWhile (· == ',')
+    { step with tacticString := s!"{tacticString} [{rwPart}]" }
   match stx with
   | `(tactic| rw [$_,*] $(_)?)      => prettifyRw "rw" steps
   | `(tactic| erw [$_,*] $(_)?)     => prettifyRw "erw" steps

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -145,12 +145,17 @@ def prettifySteps (stx : Syntax) (steps : List ProofStep) : List ProofStep := Id
   match stx with
   | `(tactic| rw [$_,*] $(_)?)
   | `(tactic| rewrite [$_,*] $(_)?) =>
-    let prettify (tStr : String) :=
-      let res := tStr.trim.dropRightWhile (· == ',')
-      -- rw puts final rfl on the "]" token
-      if res == "]" then "rfl" else res
-    return steps.map fun a => { a with tacticString := s!"rw [{prettify a.tacticString}]" }
-  | _ => return steps
+    return steps.map λ step =>
+      let rwPart := if step.tacticString == "]"
+        then "rfl"
+        else step.tacticString.trim.dropRightWhile (· == ',')
+      -- EXAMPLE
+      -- "Set.mem_inter_iff," => "rw [Set.mem_inter_iff]"
+      -- "and_comm"           => "rw [and_comm]"
+      -- "]"                  => "rw [rfl]"
+      { step with tacticString := s!"rw [{rwPart}]" }
+  | _ =>
+    return steps
 
 -- Comparator for names, e.g. so that _uniq.34 and _uniq.102 go in the right order.
 -- That's not completely right because it doesn't compare prefixes but

--- a/lean/BetterParser.lean
+++ b/lean/BetterParser.lean
@@ -94,7 +94,7 @@ def printGoalInfo (ctx : ContextInfo) (metavarContext : MetavarContext) (id : MV
       return acc
     let type ← ppExprWithInfos ppContext hypDecl.type
     let value ← liftM (hypDecl.value?.mapM (ppExprWithInfos ppContext))
-    let isProof : String ← mayBeProof hypDecl.toExpr
+    let isProof : String ← ContextInfo.runMetaM printCtx decl.lctx (mayBeProof hypDecl.toExpr)
     return ({
       username := hypDecl.userName.toString,
       type := type.fmt.pretty,


### PR DESCRIPTION
I was pushing this to `main`, but parser requires more care than that 😅

This PR:
- adds some other `rwa`/`nth_rw`/etc. `rw` rules handling
- adds line numbers to the parser output
- refactors the code (not in any meaningful way really, just to make it easier to work with for me - mostly educational refactors. does add some nice things too though!)

As it stands, the new parser sort of works, but doesn't handle rewrites well in this Carleson's lemma e.g.

```
lemma calculation_1 (s : ℤ) :
    4 * (D : ℝ) ^ (-2 : ℝ) * D ^ (s + 3) = 4 * D ^ (s + 1) := by
  have D_pos : (0 : ℝ) < D := defaultD_pos a
  calc 4 * (D : ℝ) ^ (-2 : ℝ) * D ^ (s + 3)
  _ = 4 * (D ^ (-2 : ℝ) * D ^ (s + 3)) := by
    ring
  _ = 4 * D ^ (-2 + (s + 3)) := by
    congr
    have pow_th := Real.rpow_add (x := (D : ℝ)) (y := (-2)) (z := (s + 3)) D_pos
    rw_mod_cast [pow_th]
  _ = 4 * D ^ (s + 1) := by
    ring_nf
 ```
 
 The way to proceed with this PR is to make `TEST.lean` work, add many test cases, and make sure each of them works when we change stuff.